### PR TITLE
Implemented IK for shifted LED location + update to setup README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The UV-LED converts an electric current into UV light.
   **3.2** Press toolbar's `Run` -> `Configure interpreter`.  
   **3.3** Select `MicroPython (ESP32)` on the second line.  
   **3.4** Press the bottom `Install or update MicroPython (esptool)`.  
-  **3.5** download v.1.23.0 of micropython for our esp32-s2 chip [here](https://micropython.org/resources/firmware/LOLIN_S2_MINI-20240602-v1.23.0.bin)  
+  **3.5** download v.1.23.0 of micropython for our esp32-s2 chip [here](https://micropython.org/resources/firmware/LOLIN_S2_MINI-20240602-v1.23.0.bin).  
   **3.6** Select from the button near "install" (hamburger icon) "select local micropython image" and select our downloaded file.  
   **3.7** Press the `Install` button and wait for "Done" message!  
   **3.8** **Press the small reset button (marked "RST" on the PCB).**  

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The UV-LED converts an electric current into UV light.
   **3.2** Press toolbar's `Run` -> `Configure interpreter`.  
   **3.3** Select `MicroPython (ESP32)` on the second line.  
   **3.4** Press the bottom `Install or update MicroPython (esptool)`.  
-  **3.5** download v.1.23.0 of micropython for our esp32-s2 chip [here](https://micropython.org/resources/firmware/LOLIN_S2_MINI-20240602-v1.23.0.bin)
+  **3.5** download v.1.23.0 of micropython for our esp32-s2 chip [here](https://micropython.org/resources/firmware/LOLIN_S2_MINI-20240602-v1.23.0.bin)  
   **3.6** Select from the button near "install" (hamburger icon) "select local micropython image" and select our downloaded file.  
   **3.7** Press the `Install` button and wait for "Done" message!  
   **3.8** **Press the small reset button (marked "RST" on the PCB).**  

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The UV-LED converts an electric current into UV light.
   **3.2** Press toolbar's `Run` -> `Configure interpreter`.  
   **3.3** Select `MicroPython (ESP32)` on the second line.  
   **3.4** Press the bottom `Install or update MicroPython (esptool)`.  
-  **3.5** Select `MicroPython family` = `ESP32-S2`.  
-  **3.6** Select `variant` = `Wemos S2 mini`.  
+  **3.5** download v.1.23.0 of micropython for our esp32-s2 chip [here](https://micropython.org/resources/firmware/LOLIN_S2_MINI-20240602-v1.23.0.bin)
+  **3.6** Select from the button near "install" (hamburger icon) "select local micropython image" and select our downloaded file.
   **3.7** Press the `Install` button and wait for "Done" message!  
   **3.8** **Press the small reset button (marked "RST" on the PCB).**  
   **3.9** Close the sub dialog (press ESC) and press `OK` on the main dialog (press ENTER).  

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The UV-LED converts an electric current into UV light.
   **3.3** Select `MicroPython (ESP32)` on the second line.  
   **3.4** Press the bottom `Install or update MicroPython (esptool)`.  
   **3.5** download v.1.23.0 of micropython for our esp32-s2 chip [here](https://micropython.org/resources/firmware/LOLIN_S2_MINI-20240602-v1.23.0.bin)
-  **3.6** Select from the button near "install" (hamburger icon) "select local micropython image" and select our downloaded file.
+  **3.6** Select from the button near "install" (hamburger icon) "select local micropython image" and select our downloaded file.  
   **3.7** Press the `Install` button and wait for "Done" message!  
   **3.8** **Press the small reset button (marked "RST" on the PCB).**  
   **3.9** Close the sub dialog (press ESC) and press `OK` on the main dialog (press ENTER).  

--- a/micropython/examples/advanced/test_draw.py
+++ b/micropython/examples/advanced/test_draw.py
@@ -2,7 +2,6 @@ from sys import modules
 from time import sleep
 from pm import PM
 
-
 class Draw:
 
     _HEART_POLY = [
@@ -126,6 +125,12 @@ class Draw:
         sleep(2)
         self._pm.rgb_leds.off()
         self._end(**kw)
+    
+    def test_lines(self, **kw):
+        self._begin(draw_speed=1)
+        self._pm.draw_line((0, 20), (0, 50))
+        self._pm.draw_circle(0, 40, 10)
+        self._end(**kw)
 
 
 def main():
@@ -159,7 +164,7 @@ Press Ctrl-C to exit.
     print('''
 Done!
 Can press Ctrl-D to soft-reset.
-    ''')
+        ''')
 
 
 if __name__ == '__main__':

--- a/micropython/examples/advanced/test_draw.py
+++ b/micropython/examples/advanced/test_draw.py
@@ -50,11 +50,6 @@ class Draw:
         self._pm.draw_regular_poly(0, 40, 20, 6)
         self._end(**kw)
 
-    def centered_hexagon(self, **kw):
-        self._begin()
-        self._pm.draw_regular_poly(0, 40, 20, 6)
-        self._end(**kw)
-
     def heart_line(self, **kw):
         self._begin()
         self._pm.rgb_leds.fill('red')

--- a/micropython/examples/basic/test_ik_roundtrip.py
+++ b/micropython/examples/basic/test_ik_roundtrip.py
@@ -1,0 +1,28 @@
+from pm import PM
+from math import sqrt
+
+
+def test_led_d_round_trip(pm, points):
+    """
+    test kinematics of offsetting the location of the led is correct by checking inversion property.
+    """
+    errs = []
+    for (lx, ly) in points:
+        print('original led point: ',lx,ly)
+        dx, dy = pm.get_eo_location_from_led(lx, ly)
+        print('d point: ',dx,dy)
+        lx2, ly2 = pm.get_led_location_from_eo(dx, dy)
+        print('reflexivity test led point: ',lx2,ly2)
+        err = sqrt((lx2 - lx)**2 + (ly2 - ly)**2)
+        print('error: ',err)
+        errs.append(err)
+    return max(errs), sum(errs)/len(errs)
+
+def main():
+    pm = PM(move_home=False)
+    pts = [( -20, 30), ( 20, 30), ( 20, 50), ( -20, 50), ( -20, 30)]
+    max_err, mean_err = test_led_d_round_trip(pm, pts)
+    print(f"max_err={max_err:.4f}, mean_err={mean_err:.4f}")
+
+if __name__ == '__main__':
+    main()

--- a/micropython/examples/basic/test_rtttl.py
+++ b/micropython/examples/basic/test_rtttl.py
@@ -1,0 +1,39 @@
+from sys import modules
+from time import sleep
+from pm import PM
+from rtttl_songs import get_rtttl_song_names, get_rtttl_song_by_name
+
+pm = PM()
+
+def main():
+    MELODIES = get_rtttl_song_names()
+    play_idx = 0
+    print('''
+Test music!
+Press buttons to draw next or previous drawing. 
+Press Ctrl-C to exit.
+    ''')
+    try:
+        while True:
+            btn = (not pm.btn_l.value()) * 1 + (not pm.btn_r.value()) * 2
+            if btn and btn != last_btn:
+                if btn == 1:
+                    play_idx = play_idx + 1 if play_idx < len(MELODIES) - 2 else 0
+                elif btn == 2:
+                    play_idx = play_idx - 1 if play_idx else len(play_idx) - 1
+                play_name = MELODIES[play_idx]
+                print('Playing:', play_name)
+                pm.buzzer.play_rtttl(get_rtttl_song_by_name(play_name))
+            last_btn = btn
+    except KeyboardInterrupt:
+        pass
+    pm.set_enable(False)
+    modules.clear() # make sure we can re-import the example!
+    print('''
+Done!
+Can press Ctrl-D to soft-reset.
+    ''')
+
+
+if __name__ == '__main__':
+    main()

--- a/micropython/lib/pm.py
+++ b/micropython/lib/pm.py
@@ -120,15 +120,13 @@ class PM:
         if OFFSET <= 0:
             return x, y
 
-        l_a, r_a = self.compute_angles_fbk(x,y)
-        print('angles (only left relevant for now): ',l_a, r_a)
+        l_a, _ = self.compute_angles_fbk(x,y)
         l_a = radians(l_a)
         t = OFFSET / PM_BAR2
 
         #forward kinematics
         c_x = PM_BAR1 * cos(l_a) - PM_BAR0 / 2
         c_y = PM_BAR1 * sin(l_a)
-        print('c is at: ', c_x, c_y)
         d_x = x
         d_y = y
         led_x = c_x + (d_x - c_x) * (1 - t)
@@ -161,16 +159,12 @@ class PM:
         if OFFSET <= 0:
             return x, y
         # when starting from LED, the effective length of PM_BAR2 is shortened by the offset.
-        l_a, r_a = self.compute_angles_fbk(x,y,bar2_length=PM_BAR2-OFFSET)
-        print('angles (only left relevant for now): ',l_a, r_a)
+        l_a, _ = self.compute_angles_fbk(x,y,bar2_length=PM_BAR2-OFFSET)
         l_a = radians(l_a)
         t = OFFSET / PM_BAR2
-        print('offset, pmbar2:', OFFSET, PM_BAR2)
-        print('relative location of led on bar: ',t)
         #forward kinematics
         c_x = PM_BAR1 * cos(l_a) - PM_BAR0 / 2
         c_y = PM_BAR1 * sin(l_a)
-        print('c is at: ', c_x, c_y)
         d_x = (x - (t * c_x)) / (1 - t)
         d_y = (y - (t * c_y)) / (1 - t)
         return d_x, d_y
@@ -187,10 +181,8 @@ class PM:
 
         l_s = sqrt(l_ss)
         r_s = sqrt(r_ss)
-        print('segment length between midpoint and servos [l,r]:', l_s, r_s)
         l_a = degrees(asin(y / l_s))
         r_a = degrees(asin(y / r_s))
-        print('segment angle between midpoint and servos rad [l,r]:', radians(l_a), radians(r_a))
         if l_x <= 0:
             l_a = 180 - l_a
 
@@ -209,13 +201,10 @@ class PM:
 
 
     def set_axes_fbk(self, x, y):
-        print('initial xy: ', x, y)
         if not self.is_within_canvas(x,y):
             raise IndexError(f"x,y location ({x},{y}) is out of canvas.")
         x,y = self.get_eo_location_from_led(x,y)
-        print(x,y)
         l_a, r_a = self.compute_angles_fbk(x,y)
-        print('angles: ',l_a,r_a)
         self.set_axes(l_a, r_a)
 #         max_a = max(abs(self._last_l_angle - l_a), abs(self._last_r_angle - r_a))
 #         self._last_l_angle = l_a

--- a/micropython/lib/pm.py
+++ b/micropython/lib/pm.py
@@ -154,7 +154,7 @@ class PM:
         """
    +---------------------------------------+
    |                                       |
-   |                  (eo)                  |
+   |                  (eo)                 |
    |     OFFSET --> /     \                |
    |           (x,y)         \             |
    |          /                 \          |
@@ -211,7 +211,8 @@ class PM:
         l_cos = (b1b2 + l_ss) / (bb1 * l_s)
         r_cos = (b1b2 + r_ss) / (bb1 * r_s)
         if not (-1 < l_cos < 1 or -1 < r_cos < 1):
-            logger.warning(f"cos of IK out of bounds, clipping. (l_cos: {l_cos},r_cos:{r_cos})")
+            logger.warning(f"cos of IK out of bounds, skipping. (l_cos: {l_cos},r_cos:{r_cos})")
+            raise IndexError
 
         l_a += degrees(acos(max(-1, min(1, l_cos))))
         r_a += degrees(acos(max(-1, min(1, r_cos))))
@@ -225,8 +226,12 @@ class PM:
         if not self.is_within_canvas(x,y):
             logger.warning(f"x,y location ({x},{y}) is out of canvas. skipping render.")
             return 0
-        x,y = self.get_eo_location_from_led(x,y)
-        l_a, r_a = self.compute_angles_fbk(x,y)
+        try:
+            x,y = self.get_eo_location_from_led(x,y)
+            l_a, r_a = self.compute_angles_fbk(x,y)
+        except IndexError:
+            print('skipping angle out of bounds render.')
+            return 0
         self.set_axes(l_a, r_a)
 #         max_a = max(abs(self._last_l_angle - l_a), abs(self._last_r_angle - r_a))
 #         self._last_l_angle = l_a

--- a/micropython/lib/pm.py
+++ b/micropython/lib/pm.py
@@ -32,7 +32,6 @@ from secrets import SERVO_US
 from math import sin, cos, asin, acos, tau, radians, degrees, sqrt, floor
 from time import sleep_ms, sleep_us
 
-
 HW_VERSION = const(3)
 SW_VERSION = const(1)
 
@@ -57,7 +56,7 @@ SERVO_ANGLES = const(170)
 PM_BAR0 = const(16)
 PM_BAR1 = const(34)
 PM_BAR2 = const(43)
-
+OFFSET = const(10)
 
 class PM:
     HOME_POINT = (0, 18)
@@ -111,12 +110,37 @@ class PM:
     def set_axes(self, l, r):
         self.set_angles(180 - l, r)
 
-    def get_linkage_d_location(self,x,y,offset=0.1):
+    def is_within_canvas(self, x, y):
+        return self.X_MIN <= x <= self.X_MAX and self.Y_MIN <= y <= self.Y_MAX
+
+    def get_led_location_from_eo(self,x,y):
+        """
+        reverse of get eo location from led, for testing f^-1(f(x))=x.
+        """
+        if OFFSET <= 0:
+            return x, y
+
+        l_a, r_a = self.compute_angles_fbk(x,y)
+        print('angles (only left relevant for now): ',l_a, r_a)
+        l_a = radians(l_a)
+        t = OFFSET / PM_BAR2
+
+        #forward kinematics
+        c_x = PM_BAR1 * cos(l_a) - PM_BAR0 / 2
+        c_y = PM_BAR1 * sin(l_a)
+        print('c is at: ', c_x, c_y)
+        d_x = x
+        d_y = y
+        led_x = c_x + (d_x - c_x) * (1 - t)
+        led_y = c_y + (d_y - c_y) * (1 - t)
+        return led_x, led_y
+
+    def get_eo_location_from_led(self,x,y):
         """
    +---------------------------------------+
    |                                       |
-   |                  (D)                  |
-   |                /     \                |
+   |                  (eo)                  |
+   |     OFFSET --> /     \                |
    |           (x,y)         \             |
    |          /                 \          |
    |    PM_BAR2                    \       |
@@ -130,21 +154,30 @@ class PM:
    |         \                   /         |
    |           \               /           |
    +-----------(B)--PM_BAR0-(A)------------+{0}
-        given the pair (x,y), where (x,y) is the location shown in the diagram,
-        return the location of the linkage point D in (x,y) coordinates.
-        The offset is the distance between the linkage point D and the LED in units.
-        The lengths between A and B is PM_BAR0,
-        The lengths between B and C is PM_BAR1,
-        The lengths between C and D is PM_BAR2,
+        given the pair (x,y), where (x,y) is the location shown in the diagram (where the led is located)
+        return the location of the end effector (eo) in (x,y) coordinates.
+        The offset is the distance between the end effector and the LED in *units* along PM_BAR2.
         """
-        
-        pass
+        if OFFSET <= 0:
+            return x, y
+        # when starting from LED, the effective length of PM_BAR2 is shortened by the offset.
+        l_a, r_a = self.compute_angles_fbk(x,y,bar2_length=PM_BAR2-OFFSET)
+        print('angles (only left relevant for now): ',l_a, r_a)
+        l_a = radians(l_a)
+        t = OFFSET / PM_BAR2
+        print('offset, pmbar2:', OFFSET, PM_BAR2)
+        print('relative location of led on bar: ',t)
+        #forward kinematics
+        c_x = PM_BAR1 * cos(l_a) - PM_BAR0 / 2
+        c_y = PM_BAR1 * sin(l_a)
+        print('c is at: ', c_x, c_y)
+        d_x = (x - (t * c_x)) / (1 - t)
+        d_y = (y - (t * c_y)) / (1 - t)
+        return d_x, d_y
 
-    def set_axes_fbk(self, x, y):
-        if x < self.X_MIN or y < self.Y_MIN or x > self.X_MAX or y > self.Y_MAX:
-            return 0
-
+    def compute_angles_fbk(self,x,y, bar2_length = PM_BAR2):
         half_b0 = PM_BAR0 / 2
+        
         l_x = x + half_b0
         r_x = x - half_b0
 
@@ -154,10 +187,10 @@ class PM:
 
         l_s = sqrt(l_ss)
         r_s = sqrt(r_ss)
-
+        print('segment length between midpoint and servos [l,r]:', l_s, r_s)
         l_a = degrees(asin(y / l_s))
         r_a = degrees(asin(y / r_s))
-
+        print('segment angle between midpoint and servos rad [l,r]:', radians(l_a), radians(r_a))
         if l_x <= 0:
             l_a = 180 - l_a
 
@@ -165,19 +198,30 @@ class PM:
             r_a = 180 - r_a
 
         bb1 = 2 * PM_BAR1
-        b1b2 = PM_BAR1 ** 2 - PM_BAR2 ** 2
+        b1b2 = PM_BAR1 ** 2 - bar2_length ** 2
 
         l_a += degrees(acos((b1b2 + l_ss) / (bb1 * l_s)))
         r_a += degrees(acos((b1b2 + r_ss) / (bb1 * r_s)))
 
         r_a = 180 - r_a
+        
+        return l_a, r_a
 
+
+    def set_axes_fbk(self, x, y):
+        print('initial xy: ', x, y)
+        if not self.is_within_canvas(x,y):
+            raise IndexError(f"x,y location ({x},{y}) is out of canvas.")
+        x,y = self.get_eo_location_from_led(x,y)
+        print(x,y)
+        l_a, r_a = self.compute_angles_fbk(x,y)
+        print('angles: ',l_a,r_a)
         self.set_axes(l_a, r_a)
 #         max_a = max(abs(self._last_l_angle - l_a), abs(self._last_r_angle - r_a))
 #         self._last_l_angle = l_a
 #         self._last_r_angle = r_a
 #         return max_a
-
+    
     def _move_to(self, p_x, p_y, speed):
         d_x = p_x - self._last_x
         d_y = p_y - self._last_y

--- a/micropython/lib/pm.py
+++ b/micropython/lib/pm.py
@@ -72,7 +72,7 @@ SERVO_ANGLES = const(170)
 PM_BAR0 = const(16)
 PM_BAR1 = const(34)
 PM_BAR2 = const(43)
-OFFSET = const(10)
+OFFSET = const(0)
 
 
 class PM:
@@ -223,7 +223,8 @@ class PM:
 
     def set_axes_fbk(self, x, y):
         if not self.is_within_canvas(x,y):
-            raise IndexError(f"x,y location ({x},{y}) is out of canvas.")
+            logger.warning(f"x,y location ({x},{y}) is out of canvas. skipping render.")
+            return 0
         x,y = self.get_eo_location_from_led(x,y)
         l_a, r_a = self.compute_angles_fbk(x,y)
         self.set_axes(l_a, r_a)

--- a/micropython/lib/pm.py
+++ b/micropython/lib/pm.py
@@ -111,6 +111,35 @@ class PM:
     def set_axes(self, l, r):
         self.set_angles(180 - l, r)
 
+    def get_linkage_d_location(self,x,y,offset=0.1):
+        """
+   +---------------------------------------+
+   |                                       |
+   |                  (D)                  |
+   |                /     \                |
+   |           (x,y)         \             |
+   |          /                 \          |
+   |    PM_BAR2                    \       |
+   |    /                             \    |
+   | /                                   \ |
+   (C)                                   (O)
+   | \                                   / |
+   |   \                               /   |
+   |   PM_BAR1                       /     |
+   |       \                       /       |
+   |         \                   /         |
+   |           \               /           |
+   +-----------(B)--PM_BAR0-(A)------------+{0}
+        given the pair (x,y), where (x,y) is the location shown in the diagram,
+        return the location of the linkage point D in (x,y) coordinates.
+        The offset is the distance between the linkage point D and the LED in units.
+        The lengths between A and B is PM_BAR0,
+        The lengths between B and C is PM_BAR1,
+        The lengths between C and D is PM_BAR2,
+        """
+        
+        pass
+
     def set_axes_fbk(self, x, y):
         if x < self.X_MIN or y < self.Y_MIN or x > self.X_MAX or y > self.Y_MAX:
             return 0


### PR DESCRIPTION
closes #1 

main changes:
- Added logic for IK + FK of LED given offset OFFSET (added const in pm.py) along the left PM_BAR2 as described in issue.
- Added test for logic (test_ik_roundtrip.py)

Note:
- the bounds of the canvas (relative to the led) + out-of-bounds logic are the same. 
- note possible edge cases with offsets that make the desired location impossible to reach. In that case skipped the rendering, same as canvas out-of-bounds logic. Can discuss if necessary.